### PR TITLE
Add build for cargo install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
-env:
-- RUST_CHANNEL=nightly
-- PROJECT_NAME=rustfmt-clippy
-
 matrix:
   include:
   - services: docker
     env:
     # this uses cargo install rustfmt and clippy
+    - RUST_CHANNEL=nightly
+    - PROJECT_NAME=rustfmt-clippy
     - CARGO_INSTALL=true
     - IMAGE_NAME=$DOCKER_USERNAME/$PROJECT_NAME
     - DOCKERFILE_DIR=cargo-install/
   - services: docker
     env:
     # this uses git master branch from rustfmt and rust-clippy instead
+    - RUST_CHANNEL=nightly
+    - PROJECT_NAME=rustfmt-clippy
     - CARGO_INSTALL=false
     - IMAGE_NAME=$DOCKER_USERNAME/$PROJECT_NAME-git-master
     - DOCKERFILE_DIR=git-install/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - DOCKERFILE_DIR=git-install/
 
 before_script:
-- set -euo pipefail
+- set -e
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,7 @@ before_script:
   fi
 
 script:
-- >-
-  docker build
-    -t $IMAGE_NAME
-    --build-arg RUST_CHANNEL=$RUST_CHANNEL $DOCKERFILE_DIR
+- docker build -t $IMAGE_NAME --build-arg RUST_CHANNEL=$RUST_CHANNEL $DOCKERFILE_DIR
 
 after_success:
 # left out of if-statement to test commands even in PRs

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,14 @@ before_script:
   fi
 
 script:
-- docker build -t $IMAGE_NAME --build-arg RUST_CHANNEL=$RUST_CHANNEL $DOCKERFILE_DIR
+- docker build -t $IMAGE_NAME --build-arg RUST_CHANNEL=$RUST_CHANNEL \
+    $DOCKERFILE_DIR
 
 after_success:
 # left out of if-statement to test commands even in PRs
-- >-
-  export RUST_DATE=$(docker run -it $IMAGE_NAME rustc --version |
+- export RUST_DATE=$(docker run -it $IMAGE_NAME rustc --version | \
     grep -oE "[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}")
-- >-
-  export RUST_VER=$(docker run -it $IMAGE_NAME rustc --version |
+- export RUST_VER=$(docker run -it $IMAGE_NAME rustc --version | \ 
     grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]")
 - export TAG1="$RUST_VER-$RUST_CHANNEL"
 - export TAG2="$RUST_CHANNEL-$RUST_DATE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,53 @@
-services:
-- docker
+env:
+- RUST_CHANNEL=nightly
+- PROJECT_NAME=rustfmt-clippy
 
-script:
-- export RUST_CHANNEL="nightly"
-- if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+matrix:
+  include:
+  - services: docker
+    env:
+    # this uses cargo install rustfmt and clippy
+    - CARGO_INSTALL=true
+    - IMAGE_NAME=$DOCKER_USERNAME/$PROJECT_NAME
+    - DOCKERFILE_DIR=cargo-install/
+  - services: docker
+    env:
+    # this uses git master branch from rustfmt and rust-clippy instead
+    - CARGO_INSTALL=false
+    - IMAGE_NAME=$DOCKER_USERNAME/$PROJECT_NAME-git-master
+    - DOCKERFILE_DIR=git-install/
+
+before_script:
+- set -euo pipefail
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
   fi
-- docker build -t $DOCKER_USERNAME/rustfmt-clippy --build-arg RUST_CHANNEL=${RUST_CHANNEL} .
-- export RUST_DATE=$(docker run -it $DOCKER_USERNAME/rustfmt-clippy rustc --version | grep -oE "[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}")
-- export TAG="${RUST_CHANNEL}-${RUST_DATE}"
 
-after_success: |
-  if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-    docker push $DOCKER_USERNAME/rustfmt-clippy
-    docker tag $DOCKER_USERNAME/rustfmt-clippy $DOCKER_USERNAME/rustfmt-clippy:$TAG
-    docker push $DOCKER_USERNAME/rustfmt-clippy:$TAG
+script:
+- >-
+  docker build
+    -t $IMAGE_NAME
+    --build-arg RUST_CHANNEL=$RUST_CHANNEL $DOCKERFILE_DIR
+
+after_success:
+# left out of if-statement to test commands even in PRs
+- >-
+  export RUST_DATE=$(docker run -it $IMAGE_NAME rustc --version |
+    grep -oE "[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}")
+- >-
+  export RUST_VER=$(docker run -it $IMAGE_NAME rustc --version |
+    grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]")
+- export TAG1="$RUST_VER-$RUST_CHANNEL"
+- export TAG2="$RUST_CHANNEL-$RUST_DATE"
+- export TAG3="$RUST_CHANNEL"
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    docker push $IMAGE_NAME;
+    docker tag $IMAGE_NAME $IMAGE_NAME:$TAG1;
+    docker push $IMAGE_NAME:$TAG1;
+    docker tag $IMAGE_NAME $IMAGE_NAME:$TAG2;
+    docker push $IMAGE_NAME:$TAG2;
+    docker tag $IMAGE_NAME $IMAGE_NAME:$TAG3;
+    docker push $IMAGE_NAME:$TAG3;
   fi
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,14 @@ before_script:
   fi
 
 script:
-- docker build -t $IMAGE_NAME --build-arg RUST_CHANNEL=$RUST_CHANNEL \
+- docker build -t $IMAGE_NAME --build-arg RUST_CHANNEL=$RUST_CHANNEL
     $DOCKERFILE_DIR
 
 after_success:
 # left out of if-statement to test commands even in PRs
-- export RUST_DATE=$(docker run -it $IMAGE_NAME rustc --version | \
+- export RUST_DATE=$(docker run -it $IMAGE_NAME rustc --version |
     grep -oE "[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}")
-- export RUST_VER=$(docker run -it $IMAGE_NAME rustc --version | \ 
+- export RUST_VER=$(docker run -it $IMAGE_NAME rustc --version |
     grep -oE "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]")
 - export TAG1="$RUST_VER-$RUST_CHANNEL"
 - export TAG2="$RUST_CHANNEL-$RUST_DATE"

--- a/README.md
+++ b/README.md
@@ -1,27 +1,43 @@
 # rustfmt-clippy
 
-Dockerfile to include rustc, cargo, rustfmt and clippy, executable for any user.
-This is an Ubuntu based image.
+Includes two Dockerfiles to include rustc, cargo, rustfmt and clippy, meant to
+be executable for any user. Both Dockerfiles are based on `ubuntu:xenial`.
+
+The non-suffixed `git-master` image performs `cargo install rustfmt` and
+`cargo install clippy`. The suffixed `git-master` image performs `git checkout`
+for both `rustfmt` and `rust-clippy` at `master` branch, and performs
+compilation and installation from there.
 
 Periodically run by CI to automatically push valid Docker images into the
 [Docker registry](https://hub.docker.com/r/guangie88/rustfmt-clippy).
 
 This repository is clearly inspired by:
-[https://github.com/clux/muslrust](https://github.com/clux/muslrust), but
-the purpose is to have a quick way to get a working Rust linting environment
-set-up for CI/CD.
+[https://github.com/clux/muslrust](https://github.com/clux/muslrust), so thanks
+to the author.
 
-## Script executed by CI
+This should hopefully help to get an easy-to-use working Rust formatting and
+code linting environment set-up for CI/CD.
+
+## Scripts executed by CI
 
 ```bash
-docker build -t --build-arg RUST_CHANNEL=${RUST_CHANNEL} guangie88/rustfmt-clippy .
+docker build \
+    --build-arg RUST_CHANNEL=${RUST_CHANNEL} \
+    -t guangie88/rustfmt-clippy
+    cargo-install/
 ```
 
-If the build fails, which can be quite frequent because of instability of
-both the `rustc` nightly compiler and `clippy`, the image will fail to be
-built.
+```bash
+docker build \
+    --build-arg RUST_CHANNEL=${RUST_CHANNEL} \
+    -t guangie88/rustfmt-clippy-git-master
+    git-install/
+```
 
-## Development libraries included
+If any of the builds fails due to the instability of `rustc` nightly compiler
+and `clippy`, the image will not be pushed into the Docker registry.
+
+## Development libraries included for both set-ups
 
 * `libssl-dev`
 * `libcurl3`

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Includes two Dockerfiles to include rustc, cargo, rustfmt and clippy, meant to
 be executable for any user. Both Dockerfiles are based on `ubuntu:xenial`.
 
 The non-suffixed `git-master` image performs `cargo install rustfmt` and
-`cargo install clippy`. The suffixed `git-master` image performs `git checkout`
-for both `rustfmt` and `rust-clippy` at `master` branch, and performs
-compilation and installation from there.
+`cargo install clippy`. The suffixed `git-master` image performs `git clone` for
+both `rustfmt` and `rust-clippy` at `master` branch, and performs compilation
+and installation from there.
 
 Periodically run by CI to automatically push valid Docker images into the
 [Docker registry](https://hub.docker.com/r/guangie88/rustfmt-clippy).

--- a/cargo-install/Dockerfile
+++ b/cargo-install/Dockerfile
@@ -1,12 +1,10 @@
 FROM ubuntu:xenial
 
 ARG RUST_CHANNEL=nightly
-ARG RUSTFMT_REV="-b master"
-ARG CLIPPY_REV="-b master"
 ARG BIN_PATH=/usr/local/bin
-ARG CARGO_ROOT_BIN_PATH=/root/.cargo/bin
+ARG CARGO_HOME=/root/.cargo
 
-RUN set -x \
+RUN set -ux \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     build-essential \
@@ -26,22 +24,12 @@ RUN set -x \
     --channel=${RUST_CHANNEL} \
     && rustc --version \
     && cargo --version \
-    && git clone https://github.com/rust-lang-nursery/rustfmt.git ${RUSTFMT_REV} \
-    && cd rustfmt \
-    && git rev-parse HEAD \
-    && cargo install -f --path . \
-    && cd .. \
-    && rm -rf rustfmt \
-    && git clone https://github.com/rust-lang-nursery/rust-clippy.git ${CLIPPY_REV} \
-    && cd rust-clippy \
-    && git rev-parse HEAD \
-    && cargo install --path . \
-    && cd .. \
-    && rm -rf rust-clippy \ 
-    && mv ${CARGO_ROOT_BIN_PATH}/* ${BIN_PATH} \
+    && cargo install -f rustfmt \
+    && cargo install -f clippy \
+    && mv ${CARGO_HOME}/bin/* ${BIN_PATH} \
     && apt-get remove -y --auto-remove curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && rm -rf /root/.cargo
+    && rm -rf ${CARGO_HOME}
 
 WORKDIR /volume

--- a/git-install/Dockerfile
+++ b/git-install/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:xenial
+
+ARG RUST_CHANNEL=nightly
+ARG RUSTFMT_REV="-b master"
+ARG CLIPPY_REV="-b master"
+ARG BIN_PATH=/usr/local/bin
+ARG CARGO_HOME=/root/.cargo
+
+RUN set -ux \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    file \
+    libssl-dev \
+    curl \
+    libcurl3 \
+    libpq-dev \
+    pkg-config \
+    libsqlite3-dev \
+    zlib1g-dev \
+    && curl https://static.rust-lang.org/rustup.sh | sh -s -- \
+    --yes \
+    --disable-sudo \
+    --channel=${RUST_CHANNEL} \
+    && rustc --version \
+    && cargo --version \
+    && git clone https://github.com/rust-lang-nursery/rustfmt.git ${RUSTFMT_REV} \
+    && cd rustfmt \
+    && git rev-parse HEAD \
+    && cargo install -f --path . \
+    && cd .. \
+    && rm -rf rustfmt \
+    && git clone https://github.com/rust-lang-nursery/rust-clippy.git ${CLIPPY_REV} \
+    && cd rust-clippy \
+    && git rev-parse HEAD \
+    && cargo install --path . \
+    && cd .. \
+    && rm -rf rust-clippy \ 
+    && mv ${CARGO_HOME}/bin/* ${BIN_PATH} \
+    && apt-get remove -y --auto-remove curl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && rm -rf ${CARGO_HOME}
+
+WORKDIR /volume


### PR DESCRIPTION
This splits the image naming convention. Now the image name with suffix `git-master` is the variant that performs the `git clone`.

This change is because `cargo fmt`  is not very stable in terms of formatting convention when using `master` branch, so it is better to go for the more stable `cargo install` variant for the simpler named Docker images.