### PR TITLE
Upgrade Debian base image from Stretch to Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:buster-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG RUST_CHANNEL=stable


### PR DESCRIPTION
Buster is now stable, other major Docker base images like rust, buildpack-deps
use it as default.

Switch to it too, so that built libraries are binary compatible with the stable
Debian version.